### PR TITLE
Update file names

### DIFF
--- a/Mods/tech/LowDigitMANPADS/Database/Vehicle/Soldier Strela2 LDM.lua
+++ b/Mods/tech/LowDigitMANPADS/Database/Vehicle/Soldier Strela2 LDM.lua
@@ -23,7 +23,7 @@ GT.WS.fire_on_march = false;
 
 local ws = GT_t.inc_ws();
 GT.WS[ws] = {};
-set_recursive_metatable(GT.WS[ws], GT_t.WS_t.strela2_manpad);
+set_recursive_metatable(GT.WS[ws], GT_t.WS_t.strela2_LDM_manpad);
 GT.WS[ws].cockpit = {"IglaSight/IglaSight", {0.0, 0.0, 0.0}}
 GT.WS[ws].pointer = "camera";
 local __LN = GT.WS[ws].LN[1]

--- a/Mods/tech/LowDigitMANPADS/Database/Vehicle/Soldier Strela2 LDM.lua
+++ b/Mods/tech/LowDigitMANPADS/Database/Vehicle/Soldier Strela2 LDM.lua
@@ -31,7 +31,7 @@ __LN.BR[1].connector_name = "POINT_LAUNCHER";
 __LN.sightMasterMode = 1;
 __LN.sightIndicationMode = 1;
 
-GT.Name = "SA-7 Strela-2 manpad";
+GT.Name = "Soldier_Strela2_LDM";
 GT.DisplayName = _('MANPADS Strela-2 SA-7 "Grail"');
 GT.DisplayNameShort = _('SA-7');
 GT.Rate = 5;

--- a/Mods/tech/LowDigitMANPADS/Database/Vehicle/Soldier Strela2M LDM.lua
+++ b/Mods/tech/LowDigitMANPADS/Database/Vehicle/Soldier Strela2M LDM.lua
@@ -31,9 +31,9 @@ __LN.BR[1].connector_name = "POINT_LAUNCHER";
 __LN.sightMasterMode = 1;
 __LN.sightIndicationMode = 1;
 
-GT.Name = "SA-7b Strela-2M manpad";
-GT.DisplayName = _('MANPADS Strela-2M SA-7b "Grail"');
-GT.DisplayNameShort = _('SA-7b');
+GT.Name = "Soldier_Strela2M_LDM";
+GT.DisplayName = _('MANPADS Strela-2M SA-7B "Grail"');
+GT.DisplayNameShort = _('SA-7B');
 GT.Rate = 5;
 
 GT.DetectionRange  = GT.sensor.max_range_finding_target;

--- a/Mods/tech/LowDigitMANPADS/Database/Vehicle/Soldier Strela2M LDM.lua
+++ b/Mods/tech/LowDigitMANPADS/Database/Vehicle/Soldier Strela2M LDM.lua
@@ -23,7 +23,7 @@ GT.WS.fire_on_march = false;
 
 local ws = GT_t.inc_ws();
 GT.WS[ws] = {};
-set_recursive_metatable(GT.WS[ws], GT_t.WS_t.strela2m_manpad);
+set_recursive_metatable(GT.WS[ws], GT_t.WS_t.strela2m_LDM_manpad);
 GT.WS[ws].cockpit = {"IglaSight/IglaSight", {0.0, 0.0, 0.0}}
 GT.WS[ws].pointer = "camera";
 local __LN = GT.WS[ws].LN[1]

--- a/Mods/tech/LowDigitMANPADS/Database/Weapon/9M32M_LDM.lua
+++ b/Mods/tech/LowDigitMANPADS/Database/Weapon/9M32M_LDM.lua
@@ -23,7 +23,7 @@ local function simple_aa_warhead(power, caliber) -- By Saint
     return res;
 end
 
-local SA9M32M = {
+local SA9M32M_LDM = {
 	category		= CAT_MISSILES,
 	name			= "Strela-2M",
 	user_name		= _("9M32M Strela-2M"),
@@ -211,44 +211,44 @@ local SA9M32M = {
 		fin2_coeff		= 0.5,
 	},
 };
-declare_weapon(SA9M32M)
+declare_weapon(SA9M32M_LDM)
 
-GT_t.LN_t.strela2m = {}
-GT_t.LN_t.strela2m.type = 4
-GT_t.LN_t.strela2m.distanceMin = 800 --500
-GT_t.LN_t.strela2m.distanceMax = 4200 --4500
-GT_t.LN_t.strela2m.reactionTime = 2;
-GT_t.LN_t.strela2m.launch_delay = 1;
-GT_t.LN_t.strela2m.maxShootingSpeed = 0
-GT_t.LN_t.strela2m.reflection_limit = 0.22
-GT_t.LN_t.strela2m.ECM_K = -1
-GT_t.LN_t.strela2m.min_launch_angle = math.rad(-20);
-GT_t.LN_t.strela2m.inclination_correction_upper_limit = math.rad(0);
-GT_t.LN_t.strela2m.inclination_correction_bias = (0);
-GT_t.LN_t.strela2m.sensor = {}
-set_recursive_metatable(GT_t.LN_t.strela2m.sensor, GT_t.WSN_t[0])
-GT_t.LN_t.strela2m.PL = {}
-GT_t.LN_t.strela2m.PL[1] = {}
-GT_t.LN_t.strela2m.PL[1].ammo_capacity = 3
-GT_t.LN_t.strela2m.PL[1].shot_delay = 0.01
-GT_t.LN_t.strela2m.PL[1].reload_time = 120
-GT_t.LN_t.strela2m.PL[1].type_ammunition = SA9M32M.wsTypeOfWeapon;
-GT_t.LN_t.strela2m.PL[1].automaticLoader = false
-GT_t.LN_t.strela2m.BR = { { pos = {1, 0, 0}, drawArgument = 4}, }
+GT_t.LN_t.strela2m_LDM = {}
+GT_t.LN_t.strela2m_LDM.type = 4
+GT_t.LN_t.strela2m_LDM.distanceMin = 800 --500
+GT_t.LN_t.strela2m_LDM.distanceMax = 4200 --4500
+GT_t.LN_t.strela2m_LDM.reactionTime = 2;
+GT_t.LN_t.strela2m_LDM.launch_delay = 1;
+GT_t.LN_t.strela2m_LDM.maxShootingSpeed = 0
+GT_t.LN_t.strela2m_LDM.reflection_limit = 0.22
+GT_t.LN_t.strela2m_LDM.ECM_K = -1
+GT_t.LN_t.strela2m_LDM.min_launch_angle = math.rad(-20);
+GT_t.LN_t.strela2m_LDM.inclination_correction_upper_limit = math.rad(0);
+GT_t.LN_t.strela2m_LDM.inclination_correction_bias = (0);
+GT_t.LN_t.strela2m_LDM.sensor = {}
+set_recursive_metatable(GT_t.LN_t.strela2m_LDM.sensor, GT_t.WSN_t[0])
+GT_t.LN_t.strela2m_LDM.PL = {}
+GT_t.LN_t.strela2m_LDM.PL[1] = {}
+GT_t.LN_t.strela2m_LDM.PL[1].ammo_capacity = 3
+GT_t.LN_t.strela2m_LDM.PL[1].shot_delay = 0.01
+GT_t.LN_t.strela2m_LDM.PL[1].reload_time = 120
+GT_t.LN_t.strela2m_LDM.PL[1].type_ammunition = SA9M32M_LDM.wsTypeOfWeapon;
+GT_t.LN_t.strela2m_LDM.PL[1].automaticLoader = false
+GT_t.LN_t.strela2m_LDM.BR = { { pos = {1, 0, 0}, drawArgument = 4}, }
 
-GT_t.WS_t.strela2m_manpad = {};
-GT_t.WS_t.strela2m_manpad.pos = {-0.071, 1.623,0};
-GT_t.WS_t.strela2m_manpad.angles = {
+GT_t.WS_t.strela2m_LDM_manpad = {};
+GT_t.WS_t.strela2m_LDM_manpad.pos = {-0.071, 1.623,0};
+GT_t.WS_t.strela2m_LDM_manpad.angles = {
 					{math.rad(180), math.rad(-180), math.rad(-45), math.rad(80)},
 					};
-GT_t.WS_t.strela2m_manpad.drawArgument1 = 0;
-GT_t.WS_t.strela2m_manpad.drawArgument2 = 1;
-GT_t.WS_t.strela2m_manpad.omegaY = 1.5;
-GT_t.WS_t.strela2m_manpad.omegaZ = 1.5;
-GT_t.WS_t.strela2m_manpad.pidY = {p=40,i=1.0,d=7, inn = 5};
-GT_t.WS_t.strela2m_manpad.pidZ = {p=40,i=1.0,d=7, inn = 5};
-GT_t.WS_t.strela2m_manpad.reloadAngleY = -100; -- not constrained
-GT_t.WS_t.strela2m_manpad.LN = {};
-GT_t.WS_t.strela2m_manpad.LN[1] = {};
-set_recursive_metatable(GT_t.WS_t.strela2m_manpad.LN[1], GT_t.LN_t.strela2m);
-GT_t.WS_t.strela2m_manpad.LN[1].PL[1].shot_delay = 13;
+GT_t.WS_t.strela2m_LDM_manpad.drawArgument1 = 0;
+GT_t.WS_t.strela2m_LDM_manpad.drawArgument2 = 1;
+GT_t.WS_t.strela2m_LDM_manpad.omegaY = 1.5;
+GT_t.WS_t.strela2m_LDM_manpad.omegaZ = 1.5;
+GT_t.WS_t.strela2m_LDM_manpad.pidY = {p=40,i=1.0,d=7, inn = 5};
+GT_t.WS_t.strela2m_LDM_manpad.pidZ = {p=40,i=1.0,d=7, inn = 5};
+GT_t.WS_t.strela2m_LDM_manpad.reloadAngleY = -100; -- not constrained
+GT_t.WS_t.strela2m_LDM_manpad.LN = {};
+GT_t.WS_t.strela2m_LDM_manpad.LN[1] = {};
+set_recursive_metatable(GT_t.WS_t.strela2m_LDM_manpad.LN[1], GT_t.LN_t.strela2m_LDM);
+GT_t.WS_t.strela2m_LDM_manpad.LN[1].PL[1].shot_delay = 13;

--- a/Mods/tech/LowDigitMANPADS/Database/Weapon/9M32_LDM.lua
+++ b/Mods/tech/LowDigitMANPADS/Database/Weapon/9M32_LDM.lua
@@ -23,7 +23,7 @@ local function simple_aa_warhead(power, caliber) -- By Saint
     return res;
 end
 
-local SA9M32 = {
+local SA9M32_LDM = {
 	category		= CAT_MISSILES,
 	name			= "Strela-2",
 	user_name		= _("9M32 Strela-2"),
@@ -211,44 +211,44 @@ local SA9M32 = {
 		fin2_coeff		= 0.5,
 	},
 };
-declare_weapon(SA9M32)
+declare_weapon(SA9M32_LDM)
 
-GT_t.LN_t.strela2 = {}
-GT_t.LN_t.strela2.type = 4
-GT_t.LN_t.strela2.distanceMin = 800 --500
-GT_t.LN_t.strela2.distanceMax = 3200 --4500
-GT_t.LN_t.strela2.reactionTime = 2;
-GT_t.LN_t.strela2.launch_delay = 1;
-GT_t.LN_t.strela2.maxShootingSpeed = 0
-GT_t.LN_t.strela2.reflection_limit = 0.22
-GT_t.LN_t.strela2.ECM_K = -1
-GT_t.LN_t.strela2.min_launch_angle = math.rad(-20);
-GT_t.LN_t.strela2.inclination_correction_upper_limit = math.rad(0);
-GT_t.LN_t.strela2.inclination_correction_bias = (0);
-GT_t.LN_t.strela2.sensor = {}
-set_recursive_metatable(GT_t.LN_t.strela2.sensor, GT_t.WSN_t[0])
-GT_t.LN_t.strela2.PL = {}
-GT_t.LN_t.strela2.PL[1] = {}
-GT_t.LN_t.strela2.PL[1].ammo_capacity = 3
-GT_t.LN_t.strela2.PL[1].shot_delay = 0.01
-GT_t.LN_t.strela2.PL[1].reload_time = 120
-GT_t.LN_t.strela2.PL[1].type_ammunition = SA9M32.wsTypeOfWeapon;
-GT_t.LN_t.strela2.PL[1].automaticLoader = false
-GT_t.LN_t.strela2.BR = { { pos = {1, 0, 0}, drawArgument = 4}, }
+GT_t.LN_t.strela2_LDM = {}
+GT_t.LN_t.strela2_LDM.type = 4
+GT_t.LN_t.strela2_LDM.distanceMin = 800 --500
+GT_t.LN_t.strela2_LDM.distanceMax = 3200 --4500
+GT_t.LN_t.strela2_LDM.reactionTime = 2;
+GT_t.LN_t.strela2_LDM.launch_delay = 1;
+GT_t.LN_t.strela2_LDM.maxShootingSpeed = 0
+GT_t.LN_t.strela2_LDM.reflection_limit = 0.22
+GT_t.LN_t.strela2_LDM.ECM_K = -1
+GT_t.LN_t.strela2_LDM.min_launch_angle = math.rad(-20);
+GT_t.LN_t.strela2_LDM.inclination_correction_upper_limit = math.rad(0);
+GT_t.LN_t.strela2_LDM.inclination_correction_bias = (0);
+GT_t.LN_t.strela2_LDM.sensor = {}
+set_recursive_metatable(GT_t.LN_t.strela2_LDM.sensor, GT_t.WSN_t[0])
+GT_t.LN_t.strela2_LDM.PL = {}
+GT_t.LN_t.strela2_LDM.PL[1] = {}
+GT_t.LN_t.strela2_LDM.PL[1].ammo_capacity = 3
+GT_t.LN_t.strela2_LDM.PL[1].shot_delay = 0.01
+GT_t.LN_t.strela2_LDM.PL[1].reload_time = 120
+GT_t.LN_t.strela2_LDM.PL[1].type_ammunition = SA9M32_LDM.wsTypeOfWeapon;
+GT_t.LN_t.strela2_LDM.PL[1].automaticLoader = false
+GT_t.LN_t.strela2_LDM.BR = { { pos = {1, 0, 0}, drawArgument = 4}, }
 
-GT_t.WS_t.strela2_manpad = {};
-GT_t.WS_t.strela2_manpad.pos = {-0.071, 1.623,0};
-GT_t.WS_t.strela2_manpad.angles = {
+GT_t.WS_t.strela2_LDM_manpad = {};
+GT_t.WS_t.strela2_LDM_manpad.pos = {-0.071, 1.623,0};
+GT_t.WS_t.strela2_LDM_manpad.angles = {
 					{math.rad(180), math.rad(-180), math.rad(-45), math.rad(80)},
 					};
-GT_t.WS_t.strela2_manpad.drawArgument1 = 0;
-GT_t.WS_t.strela2_manpad.drawArgument2 = 1;
-GT_t.WS_t.strela2_manpad.omegaY = 1.5;
-GT_t.WS_t.strela2_manpad.omegaZ = 1.5;
-GT_t.WS_t.strela2_manpad.pidY = {p=40,i=1.0,d=7, inn = 5};
-GT_t.WS_t.strela2_manpad.pidZ = {p=40,i=1.0,d=7, inn = 5};
-GT_t.WS_t.strela2_manpad.reloadAngleY = -100; -- not constrained
-GT_t.WS_t.strela2_manpad.LN = {};
-GT_t.WS_t.strela2_manpad.LN[1] = {};
-set_recursive_metatable(GT_t.WS_t.strela2_manpad.LN[1], GT_t.LN_t.strela2);
-GT_t.WS_t.strela2_manpad.LN[1].PL[1].shot_delay = 13;
+GT_t.WS_t.strela2_LDM_manpad.drawArgument1 = 0;
+GT_t.WS_t.strela2_LDM_manpad.drawArgument2 = 1;
+GT_t.WS_t.strela2_LDM_manpad.omegaY = 1.5;
+GT_t.WS_t.strela2_LDM_manpad.omegaZ = 1.5;
+GT_t.WS_t.strela2_LDM_manpad.pidY = {p=40,i=1.0,d=7, inn = 5};
+GT_t.WS_t.strela2_LDM_manpad.pidZ = {p=40,i=1.0,d=7, inn = 5};
+GT_t.WS_t.strela2_LDM_manpad.reloadAngleY = -100; -- not constrained
+GT_t.WS_t.strela2_LDM_manpad.LN = {};
+GT_t.WS_t.strela2_LDM_manpad.LN[1] = {};
+set_recursive_metatable(GT_t.WS_t.strela2_LDM_manpad.LN[1], GT_t.LN_t.strela2_LDM);
+GT_t.WS_t.strela2_LDM_manpad.LN[1].PL[1].shot_delay = 13;

--- a/Mods/tech/LowDigitMANPADS/entry.lua
+++ b/Mods/tech/LowDigitMANPADS/entry.lua
@@ -5,7 +5,7 @@ displayName   = _("Low Digit MANPADS"),
 shortName	  =   "LowDigitMANPADS",
 state		 	  = "installed",
 developerName	  = "modified by Des, credit goes to the High Digit SAMs Mod team",
-version		 	  = "0.3",	
+version		 	  = "0.4",	
 info		  =    _("Adds Strela-2/M 9M32/M"),	 
 encyclopedia_path = current_mod_path .. '/Encyclopedia',
 })

--- a/Mods/tech/LowDigitMANPADS/entry.lua
+++ b/Mods/tech/LowDigitMANPADS/entry.lua
@@ -48,8 +48,8 @@ end
 
 --Russia
 
-weapon_file("/Database/Weapon/9M32.lua")
-weapon_file("/Database/Weapon/9M32M.lua")
+weapon_file("/Database/Weapon/9M32_LDM.lua")
+weapon_file("/Database/Weapon/9M32M_LDM.lua")
 
 --MANPADS
 

--- a/Mods/tech/LowDigitMANPADS/entry.lua
+++ b/Mods/tech/LowDigitMANPADS/entry.lua
@@ -53,8 +53,8 @@ weapon_file("/Database/Weapon/9M32M.lua")
 
 --MANPADS
 
-vehicle_file("/Database/Vehicle/Strela-2.lua")
-vehicle_file("/Database/Vehicle/Strela-2M.lua")
+vehicle_file("/Database/Vehicle/Soldier Strela2 LDM.lua")
+vehicle_file("/Database/Vehicle/Soldier Strela2M LDM.lua")
 
 
 plugin_done()


### PR DESCRIPTION
Updates all file names, internal and external, of units and weapons so that there's no chance for a conflict with another mod.

All units, files, and weapons now have the suffix "_LDM".

This is simply following good modding practice. Common in communities like ArmA, but sadly not so much in DCS.